### PR TITLE
Change Start to OnEnable in C# script

### DIFF
--- a/Scripts/VHSPostProcessEffect.cs
+++ b/Scripts/VHSPostProcessEffect.cs
@@ -15,7 +15,7 @@ public class VHSPostProcessEffect : MonoBehaviour
 	private Material _material = null;
 	private VideoPlayer _player;
 
-	void Start()
+	void OnEnable()
 	{
 		_material = new Material(shader);
 		_player = GetComponent<VideoPlayer>();


### PR DESCRIPTION
With the Start function in the code, in case of any enable/disabling the component in the runtime, the component stops working because it loses the material and doesn't recreate it. This problem is solved by changing Start to OnEnable.